### PR TITLE
Shutdown Fitnesse before running tests from Xcode

### DIFF
--- a/Pod/Support/SharedSupport/ocsp-generate-fitnesse-test-report.sh
+++ b/Pod/Support/SharedSupport/ocsp-generate-fitnesse-test-report.sh
@@ -6,6 +6,7 @@ RETURN_CODE=0
 function main {
 	echo "[OCSP_TEST] Fitnesse Test Suite=$FITNESSE_SUITE_NAME"	
 	echo "[OCSP_TEST] Destination Report File Path=$TEST_REPORT_FILE_PATH"
+	${PROJECT_DIR}/LaunchFitnesse --shutdown 2>&1 >/dev/null
 	${PROJECT_DIR}/LaunchFitnesse -d "${PROJECT_DIR}" -b "$TEST_REPORT_FILE_PATH" --test "$FITNESSE_SUITE_NAME" --verbose >&1 
 }
 


### PR DESCRIPTION
LaunchFitnesse would try to be smart and if it detects an existing instance of Fitnesse assumes it's correct for the current target.

This will create an issue where if a stale instance of Fitnesse is running and a git clean -fd was run int he repo dumping FitnesseRoot the tests would fail.

Resolved by issuing --shutdown before generating test reports when invoking LaunchFitnesse.