### PR TITLE
Double qoute path to Fitnesse in LaunchFitnesse when launching

### DIFF
--- a/Pod/Support/SharedSupport/LaunchFitnesse
+++ b/Pod/Support/SharedSupport/LaunchFitnesse
@@ -136,7 +136,7 @@ function fitnesse_start {
 	echo "[OCSP_CTL] Timeout=${FITNESSE_TIMEOUT_SECONDS}"
 	echo "[OCSP_CTL] RootPath=${FITNESSE_ROOT}"
 	echo "[OCSP_CTL] FITNESSE: Launch"
-	java -jar -Dslim.timeout=${FITNESSE_TIMEOUT_SECONDS} ${FITNESSE_EXECUTABLE_PATH} -e 0 -p ${FITNESSE_PORT} -d ${FITNESSE_ROOT} 2>/dev/null &
+	java -jar -Dslim.timeout=${FITNESSE_TIMEOUT_SECONDS} "${FITNESSE_EXECUTABLE_PATH}" -e 0 -p ${FITNESSE_PORT} -d "${FITNESSE_ROOT}" 2>/dev/null &
 }
 
 function fitnesse_wait {


### PR DESCRIPTION
Fixes an issue when launching Fitnesse in projects with a whitespace in the project path.